### PR TITLE
[MT-9044] Update minimum iOS version to 16.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "w3w-swift-components-map-apple",
   
-  platforms: [.iOS(.v13)],
+  platforms: [.iOS("16.1")],
 
   products: [
     .library(name: "W3WSwiftComponentsMapApple", targets: ["W3WSwiftComponentsMapApple"]),


### PR DESCRIPTION
## Update minimum iOS version to 16.1

Bump platform deployment target to iOS 16.1 (consumes 16.1 w3w-* products).

Part of [MT-9044](https://linear.app/what3words/issue/MT-9044/ios-update-minimum-ios-app-version-to-161).